### PR TITLE
Change default dynamic memory usage from 256M to 90% of available mem…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ sudo: required
 
 language: c
 
+env:
+  global:
+     - COMMIT=${TRAVIS_COMMIT::6}
+     - REPO=containerlisp/lisp-10-centos7
+
 services:
   - docker
 
@@ -15,6 +20,13 @@ script:
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-      docker push containerlisp/lisp-10-centos7;
+      TAG=$(date -d \
+            $(grep http://beta.quicklisp.org 1.0/root/opt/app-root/install.lisp \
+                   | awk -F'/' '{ print $6 }') \
+            +%Y%m%d).$TRAVIS_BUILD_NUMBER
+      docker images
+      docker tag $REPO:latest $REPO:$TAG
+      docker tag $REPO:latest $REPO:$COMMIT
+      docker push $REPO
     fi
   - echo All done.

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ after_success:
       TAG=$(date -d \
             $(grep http://beta.quicklisp.org 1.0/root/opt/app-root/install.lisp \
                    | awk -F'/' '{ print $6 }') \
-            +%Y%m%d).$TRAVIS_BUILD_NUMBER
-      docker images
-      docker tag $REPO:latest $REPO:$TAG
-      docker tag $REPO:latest $REPO:$COMMIT
-      docker push $REPO
+            +%Y%m%d).$TRAVIS_BUILD_NUMBER;
+      docker images;
+      docker tag $REPO:latest $REPO:$TAG;
+      docker tag $REPO:latest $REPO:$COMMIT;
+      docker push $REPO;
     fi
   - echo All done.

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,9 @@ script:
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
-      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-      TAG=$(date -d \
-            $(grep http://beta.quicklisp.org 1.0/root/opt/app-root/install.lisp \
-                   | awk -F'/' '{ print $6 }') \
-            +%Y%m%d).$TRAVIS_BUILD_NUMBER;
+      docker logout
+      docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
+      TAG=$(date -d $(grep http://beta.quicklisp.org container-lisp/s2i-lisp/1.0/root/opt/app-root/install.lisp | awk -F'/' '{ print $6 }') +%Y%m%d).$TRAVIS_BUILD_NUMBER;
       docker images;
       docker tag $REPO:latest $REPO:$TAG;
       docker tag $REPO:latest $REPO:$COMMIT;

--- a/1.0/root/usr/bin/cgroup-limits
+++ b/1.0/root/usr/bin/cgroup-limits
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Script for parsing cgroup information
+#
+# This script will read some limits from the cgroup system and parse
+# them, printing out "VARIABLE=VALUE" on each line for every limit that is
+# successfully read. Output of this script can be directly fed into
+# bash's export command. Recommended usage from a bash script:
+#
+#     source cgroup-limits
+#
+# Variables currently supported:
+#     MEMORY_LIMIT_IN_BYTES
+#         Maximum amount of user memory in bytes. The value is taken from
+#         /sys/fs/cgroup/memory/memory.limit_in_bytes
+#
+#         Fallback: physical memory (arbitary high value)
+#     CPU_CORES
+#         Number of detected CPU cores that can be used. This value is taken from
+#          `grep -c ^processor /proc/cpuinfo`
+
+PHYSICAL_MEMORY_LIMIT_IN_BYTES=$(free -b | awk 'NR==2{print$2}')
+if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+  export MEMORY_LIMIT_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+
+  # Fall back to physical memory limit if cgroups returns arbitary value
+  if (($MEMORY_LIMIT_IN_BYTES >= $PHYSICAL_MEMORY_LIMIT_IN_BYTES)); then
+    MEMORY_LIMIT_IN_BYTES=$PHYSICAL_MEMORY_LIMIT_IN_BYTES
+  fi
+else
+  export MEMORY_LIMIT_IN_BYTES=$PHYSICAL_MEMORY_LIMIT_IN_BYTES
+fi
+# Set a memory limit in MB
+export MEMORY_LIMIT=$((MEMORY_LIMIT_IN_BYTES/1024/1024))
+
+# CPU Count
+export CPU_CORES=$(grep -c ^processor /proc/cpuinfo)

--- a/1.0/s2i/bin/assemble
+++ b/1.0/s2i/bin/assemble
@@ -2,8 +2,10 @@
 
 set -e
 
+DYNAMIC_SPACE_SIZE=${APP_MEM-$((MEMORY_LIMIT * 90 / 100))}
+
 SBCL_OPTS=(
-    --dynamic-space-size "${APP_MEM-256}"
+    --dynamic-space-size "${DYNAMIC_SPACE_SIZE}"
 )
 
 echo "---> Installing application source ..."

--- a/1.0/s2i/bin/run
+++ b/1.0/s2i/bin/run
@@ -1,16 +1,20 @@
 #!/bin/bash
 
+source cgroup-limits
+
+DYNAMIC_SPACE_SIZE=${APP_MEM-$((MEMORY_LIMIT * 90 / 100))}
+
 if [ -n "$APP_SCRIPT" ]; then
     PROJECT_PATH=./quicklisp/local-projects/${APP_SYSTEM_NAME}
     SBCL_OPTS=(
         "${SBCL_OPTS[@]}"
-        --dynamic-space-size "${APP_MEM-256}"
+        --dynamic-space-size "${DYNAMIC_SPACE_SIZE}"
         --load "${PROJECT_PATH}/$(eval echo ${APP_SCRIPT})"
     )
 else
     SBCL_OPTS=(
         "${SBCL_OPTS[@]}"
-        --dynamic-space-size "${APP_MEM-256}"
+        --dynamic-space-size "${DYNAMIC_SPACE_SIZE}"
         --eval "(ql:quickload :$(eval echo ${APP_SYSTEM_NAME}))"
         --eval "$(eval echo ${APP_EVAL})"
     )

--- a/README.md
+++ b/README.md
@@ -133,3 +133,26 @@ repository.
     application needs to use this port). This setting will only come
     into effect when a development backend has been selected via
     `DEV_ENV`.
+
+Public Container Images
+-----------------------
+
+The centos7-based S2I images are published on dockerhub, as
+`containerlinux/lisp-10-centos7'.  Image tags are as follows:
+
+* `latest`: the most recent build of the very latest quicklisp, SBCL
+  and OS bits.
+
+* Quicklisp dist version date (eg. `20181210`): The latest build based
+  on this quicklisp distribution version.  If you use this tag the
+  quicklisp bits will never change, but the underlying OS and SBCL
+  bits may.
+
+* Git commit hash (eg. `b6ef12a`): The semantics of this tag are the
+  same as above. It is provided as a convenience in order to map back
+  to the original source version in this repo.
+
+* Quicklisp dist version date + travis-ci build number (eg. `20181210.26`):
+  This identifies a specific build for a specific
+  quicklisp distribution.  This is a unique build, and will never
+  change.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ repository.
     This value will be passed to sbcl via `--dynamic-space-size` and
     should be set to the amount of memory the application needs. It
     will be used for both building the image as well as running it.
-    Its default value is 256M.
+    Its default value is 90% of available memory as reported by
+    cgroups.
 
 * **DEV_BACKEND**
 


### PR DESCRIPTION
…ory.

What do you think of this change?  It changes the default so that SBCL will use 90% of the memory OpenShift makes available for the container, instead of having to manage that as a separate number.  You can still override by setting APP_MEM.  